### PR TITLE
yara-python 4.3.1 :snowflake: fix abs upload_channels

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-upload-channels:
+upload_channels:
   - sfe1ed40


### PR DESCRIPTION
yara-python 4.3.1 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3769]
- dev_url: https://github.com/VirusTotal/yara-python/tree/v4.3.1
- pypi: https://pypi.org/project/yara-python

### Explanation of changes:

- typo in `abs.yaml`, no other changes

[PKG-3769]: https://anaconda.atlassian.net/browse/PKG-3769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ